### PR TITLE
Only apps should have lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# gitignore
 node_modules
+
+# Only apps should have lockfiles
+npm-shrinkwrap.json
+package-lock.json
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
This prevents npm 5+ from creating `package-lock.json`, and also ensures that no lockfiles are unintentionally committed to the repo.

 - Using npm-shrinkwrap.json is hostile to downstream npm users, as it obstructs deduping, and is a no-op for yarn users
 - Using yarn.lock or package-lock.json gives project developers a different experience than consumers, which primarily serves to hide dependency graph issues from developers and force downstream consumers to deal with them.